### PR TITLE
feat: Add support for django 4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 MANIFEST
 dist
 build
+*.egg-info

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/nebstrebor/django-threadlocals",
     classifiers=[
-        "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,10 @@ setuptools.setup(
     description="Contains utils for storing and retreiving values from threadlocals, and middleware for placing the current Django request in threadlocal storage.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url='https://github.com/nebstrebor/django-threadlocals',
+    url="https://github.com/nebstrebor/django-threadlocals",
     classifiers=[
         "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Framework :: Django",

--- a/threadlocals/tester/urls.py
+++ b/threadlocals/tester/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, path, re_path
 
 # Uncomment the next two lines to enable the admin:
 # from django.contrib import admin
@@ -22,14 +22,14 @@ def exception_view(request):
 
 urlpatterns = [
     # Examples:
-    url(r'^$', empty_view, name='empty'),
-    url(r'query/', query_view, name='query'),
-    url(r'exception/', exception_view, name='exception'),
-    # url(r'^testrunner/', include('testrunner.foo.urls')),
+    path('', empty_view, name='empty'),
+    re_path(r'query/', query_view, name='query'),
+    re_path(r'exception/', exception_view, name='exception'),
+    # path('testrunner/', include('testrunner.foo.urls')),
 
     # Uncomment the admin/doc line below to enable admin documentation:
-    # url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
+    # path('admin/doc/', include('django.contrib.admindocs.urls')),
 
     # Uncomment the next line to enable the admin:
-    # url(r'^admin/', include(admin.site.urls)),
+    # path('admin/', include(admin.site.urls)),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[tox]
+envlist = py38-{3.2,4.1,4.2}
+
+[testenv]
+basepython =
+    py38: python3.8
+deps =
+    3.2: Django>=3.2,<3.3
+    4.1: Django>=4.1,<4.2
+    4.2: Django>=4.2,<4.3
+allowlist_externals =
+    cd
+commands =
+    cd threadlocals/tester && {envpython} manage.py test


### PR DESCRIPTION
Tested with custom `tox.ini` file

```
[tox]
skipsdist = true
args_are_paths = false
envlist =
    py38-{3.2,4.0,4.1,4.2}

[testenv]
usedevelop = true
basepython =
    py38: python3.8
deps =
    3.2: Django>=3.2,<3.3
    4.0: Django>=4.0,<4.1
    4.1: Django>=4.1,<4.2
    4.2: Django>=4.2,<4.3
setenv =
allowlist_externals =
    cd
commands =
    cd threadlocals/tester && {envpython} manage.py test

```

Output:

```
❯ tox
py38-3.2: install_deps threadlocals/tester> python -I -m pip install 'Django<3.3,>=3.2'
py38-3.2: commands[0] threadlocals/tester> cd threadlocals/tester '&&' /Users/irtazaakram/bom/django-threadlocals/.tox/py38-3.2/bin/python manage.py test
py38-3.2: OK ✔ in 12.64 seconds
py38-4.0: install_deps threadlocals/tester> python -I -m pip install 'Django<4.1,>=4.0'
py38-4.0: commands[0] threadlocals/tester> cd threadlocals/tester '&&' /Users/irtazaakram/bom/django-threadlocals/.tox/py38-4.0/bin/python manage.py test
py38-4.0: OK ✔ in 11.99 seconds
py38-4.1: install_deps threadlocals/tester> python -I -m pip install 'Django<4.2,>=4.1'
py38-4.1: commands[0] threadlocals/tester> cd threadlocals/tester '&&' /Users/irtazaakram/bom/django-threadlocals/.tox/py38-4.1/bin/python manage.py test
py38-4.1: OK ✔ in 11.84 seconds
py38-4.2: install_deps threadlocals/tester> python -I -m pip install 'Django<4.3,>=4.2'
py38-4.2: commands[0] threadlocals/tester> cd threadlocals/tester '&&' /Users/irtazaakram/bom/django-threadlocals/.tox/py38-4.2/bin/python manage.py test
  py38-3.2: OK (12.64=setup[12.61]+cmd[0.03] seconds)
  py38-4.0: OK (11.99=setup[11.96]+cmd[0.03] seconds)
  py38-4.1: OK (11.84=setup[11.81]+cmd[0.03] seconds)
  py38-4.2: OK (13.02=setup[12.98]+cmd[0.03] seconds)
  congratulations :) (49.75 seconds)
```